### PR TITLE
Hotfix: No arbitrary base file names accepted.

### DIFF
--- a/src/exam_generator/classes.py
+++ b/src/exam_generator/classes.py
@@ -43,7 +43,7 @@ class Pool:
         # [(filename_problem, filename_solution)]; problems which were pulled by last group
 
         # Creates a list with all problems of required pool
-        problem_regex = re.compile(f"^problem_\\d+\\.tex$")
+        problem_regex = re.compile(f"^problem_.+\\.tex$")
         file_names_pool_problems = [
             file for file in pool_files if re.match(problem_regex, file) is not None
         ]


### PR DESCRIPTION
**According to the documentation:**
Problems and solutions are saved in separate files. Files for problems have the prefix `problem_`, solutions the prefix `solution_`. You may follow up the prefix with any name to your liking, however mind that
problem/ solution pairs have to have the exact
same description following the prefix.

**Observation:**
Only files like `problem_xy.tex` are accepted where xy is a number.

This commit realizes what the documentation states.