### PR TITLE
Proper handling of images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@
 !/docs
 !/test 
 !/examples
+/docs/build_develop/
+/dist/
+/.idea/
+/build/lib/exam_generator/

--- a/docs/.vscode/settings.json
+++ b/docs/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "esbonio.sphinx.buildDir" : "${workspaceFolder}/build_develop",
+    "esbonio.sphinx.confDir"  : "${workspaceFolder}/source",
+    "esbonio.sphinx.srcDir"   : "${workspaceFolder}/source",
+    "restructuredtext.linter.doc8.extraArgs": ["--ignore D004"]
+}

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -26,7 +26,7 @@ As mentioned in the user documentation this project requires a specific director
 Since we would like to create an exam with three different pools, we firstly need to create three subdirectories
 in the ``pool_data`` directory. Secondly, we provide each pool with at least as many problem/ solution pairs as
 the number of different groups we would like to have. In this case we provide three problem/solution pairs for each
-pool, therefore allowing a maximum of three different groups. 
+pool, therefore allowing a maximum of three different groups.
 Lastly, we create our ``Math1.json`` settings file in the ``settings`` directory.
 
 Our requirements result in the following structure:
@@ -34,8 +34,8 @@ Our requirements result in the following structure:
 
 ::
 
-    C:.                                 ← Our current working directory                  
-    ├───pool_data                       ← Directory for all different pool directories                
+    C:.                                 ← Our current working directory
+    ├───pool_data                       ← Directory for all different pool directories
     │   ├───MC_easy                     ← Pool with easy multiple choice questions
     │   │       problem_1.tex
     │   │       problem_2.tex
@@ -60,12 +60,12 @@ Our requirements result in the following structure:
     │           solution_8.tex
     │           solution_9.tex
     │
-    ├───settings                        
-    │       Math1.json                  ← Settings file 
+    ├───settings
+    │       Math1.json                  ← Settings file
     │
     └───templates                       ← LaTeX Templates
             template_problem.tex
-            template_solution.tex 
+            template_solution.tex
 
 
 Settings
@@ -75,14 +75,14 @@ Now it is time to configure our settings in ``Math1.json``.
 
 ::
 
-    {            
+    {
     "title": "Exam for Math 1 (MA1)",   ← The title that will be displayed on the exam
     "variant_name": "Math1",            ← Short handle displayed in the file names
     "semester": "WS 2022/23",           ← Current semester
     "number_of_groups": 3,              ← Let's choose our maximum amount of possible groups
-    "copies": 1                         ← We are not using parametirization, therefore copies is set to 1                   
-    "page_format_exam": "A4",           ← Students will get their tests printed out in A4 format      
-    "page_format_solution": "A5",       ← Solution will be printed in A5 
+    "copies": 1                         ← We are not using parametirization, therefore copies is set to 1
+    "page_format_exam": "A4",           ← Students will get their tests printed out in A4 format
+    "page_format_solution": "A5",       ← Solution will be printed in A5
 
     "options":{
         "generate_single_pdfs": true,   ← We would like the option to look at the problems for each group seperately
@@ -90,7 +90,7 @@ Now it is time to configure our settings in ``Math1.json``.
         "delete_temp_data": true        ← Deleteing temporary data is always usefull
     },
 
-    "sumo_options":{                           
+    "sumo_options":{
         "exam_copies": 15,              ← Total number of students taking the exam
         "solution_copies": 1            ← There is only one solution copy required
     },
@@ -119,7 +119,7 @@ exam_generator -ct .\\settings\\Math1.json
 
 A new directory with all requested exams will be created:
 
-:: 
+::
 
     C:.
     ├───Exams-Math1-WS202223
@@ -148,7 +148,7 @@ Example 2: Multiple Exams
 Our second example focuses on creating multiple exams at once.
 It will go into further detail regarding the project settings.
 
-We would like to create three exams for three different lab experiments for 
+We would like to create three exams for three different lab experiments for
 electrical engineers in their 2nd semester.
 There is a total of 30 students attending each test and we would like to have
 two different groups. Since all of our problems/ solutions are already finalized,
@@ -158,13 +158,13 @@ Setup
 ^^^^^^^^^^^^^^^^^^^
 
 There is a total of eigth pools required for our three exams.
-Each pool contains at least two problem/ solution pairs. 
+Each pool contains at least two problem/ solution pairs.
 
 ::
 
     C:.
-    ├───pool_data               
-    │   ├───A2                          ← Starting problems 
+    ├───pool_data
+    │   ├───A2                          ← Starting problems
     │   │
     │   ├───B2                          ← Followup problems
     │   │
@@ -192,7 +192,7 @@ Settings
 Our lab exams have the following requirements:
 - The first problem is always one of pool *A2*
 - The second problem is always one of pool *B2*
-- There needs to be at least one lab specific problem 
+- There needs to be at least one lab specific problem
 
 Furthermore, we need copies for 30 students. With two groups for each test,
 that leaves us with 15 copies for our sumo file.
@@ -208,19 +208,19 @@ that leaves us with 15 copies for our sumo file.
     "page_format_exam": "A5",               ← Students will receive their exams in A5 format
     "page_format_solution": "A4",           ← Solutions in A4 format
 
-    "options":{ 
+    "options":{
         "generate_single_pdfs": false,      ← We do not need the tests for each group separately
         "generate_sumo_pdf": true,
         "delete_temp_data": true
     },
-    
-    "sumo_options":{ 
+
+    "sumo_options":{
         "sumo_problem_copies": 30,          ← 30 students
         "sumo_solution_copies": 1
     },
-    
 
-    "exams":{ 
+
+    "exams":{
         "Lab03": [                          ← First exam
         "A2",
         "B2",
@@ -252,7 +252,7 @@ exam_generator -ct .\\settings\\ET2.json
 
 Our exam directory will be created and the result is the following:
 
-::  
+::
 
     C:.
     ├───Exams-ET2-WS202223
@@ -272,7 +272,7 @@ Now you can simply print in your chosen format.
 Example 3: Parameterization
 -----------------------------
 Now that you are finally familiar with the basics, we can get to the fun stuff: creating exams with paramaters.
-This example will focus on how to implement parameters in your LaTeX problem/ solution files and how you will have 
+This example will focus on how to implement parameters in your LaTeX problem/ solution files and how you will have
 to adapt your settings to its usage.
 
 Let's again create a very simple math exam, using paramaters.
@@ -280,22 +280,22 @@ Let's again create a very simple math exam, using paramaters.
 Setup
 ^^^^^^^^^^^^^^^^^^^
 Our directory setup is exavtly the same as before. We only need to focus on the content of the problem/ solutions files
-in which we would like to implement randomly generated numbers. 
+in which we would like to implement randomly generated numbers.
 In this example we will look at problem_2.tex and its solution.
 ::
 
-    C:.                                 ← Our current working directory                  
-    ├───pool_data                       ← Directory for all different pool directories                
+    C:.                                 ← Our current working directory
+    ├───pool_data                       ← Directory for all different pool directories
     │   └───easy_calculations           ← Pool with easy multiple choice questions
-    │           problem_1.tex           
+    │           problem_1.tex
     │           problem_2.tex           ← Problem with parameters
-    │           problem_3.tex           
+    │           problem_3.tex
     │           solution_1.tex
     │           solution_2.tex          ← Solution to parameter problem
     │           solution_3.tex
     │
-    ├───settings                        
-    │       Math2.json                  ← Settings file 
+    ├───settings
+    │       Math2.json                  ← Settings file
     │
     └───templates                       ← LaTeX Templates
             template_problem.tex
@@ -308,7 +308,7 @@ Firstly, the students have to guess the correct number (randomly generated in th
 Secondly, they are asked to calculate the sum of two numbers.
 Lastly, they need find the product of two large numbers.
 
-Since the both the first parameters called in the second and third item are provided with the same key and 
+Since the both the first parameters called in the second and third item are provided with the same key and
 bounds, it will generate replace them with the same exact number.
 
 Content of problem_2.tex:
@@ -362,20 +362,20 @@ but in a different order.
     "page_format_exam": "A5",               ← Students will receive their exams in A5 format
     "page_format_solution": "A4",           ← Solutions in A4 format
 
-    "options":{ 
+    "options":{
         "generate_single_pdfs": true,       ← We will have the tests for each group
         "generate_sumo_pdf": true,
         "delete_temp_data": true
     },
-    
-    "sumo_options":{ 
+
+    "sumo_options":{
         "exam_copies": 1,                   ← When using parameterization this should be set to 1!
         "solution_copies": 1                ← We only need one copy of the solutions
     },
-    
 
-    "exams":{ 
-        "Math 101": [                          
+
+    "exams":{
+        "Math 101": [
         "easy_calculations",
         "easy_calculations",
         "easy_calculations"
@@ -391,7 +391,7 @@ exam_generator -ct .\\settings\\Math2.json
 
 Our exam directory will be created and the result is the following:
 
-::  
+::
 
     C:.
     ├───Exams-ET2-WS202223

--- a/docs/source/userdoc.rst
+++ b/docs/source/userdoc.rst
@@ -3,9 +3,9 @@ User Doc
 
 Introduction
 -----------------
-exam_generator is a script which is designed to create exams/ tests from 
+exam_generator is a script which is designed to create exams/ tests from
 pools of problems while ensuring that there will be no repetition amongst
-different groups. 
+different groups.
 The exams/ tests are based off of two major components:
 LaTeX files (problems, solutions, templates) and user defined settings.
 
@@ -16,8 +16,8 @@ Content Generation
 
 LaTeX Templates
 ^^^^^^^^^^^^^^^^^^^^^^^
-There are two LaTeX templates in the ``templates`` directory: one for problems 
-and one for sample solution and evaluation. Within the templates there are 
+There are two LaTeX templates in the ``templates`` directory: one for problems
+and one for sample solution and evaluation. Within the templates there are
 placeholders, which will later be replaced by this script.
 
 Problems/ Solutions
@@ -25,29 +25,29 @@ Problems/ Solutions
 
 Pools
 """"""""""""""""""""""""
-Problems and solutions are located in the
-``pool_data`` directory which is furthermore separated into *pools*. 
-Pools are sets of problems/ solutions of a specfic type. They can for example differ between general
-problems, that are used in every test, and problems that are specific for a given experiment. 
+Problems and solutions are located as LaTeX (```*.tex```) files in the
+``pool_data`` directory. This directory is separated into several *pool*-directories.
+Pools are sets of problems/ solutions of a specfic category. They can for example differ between general
+problems, that are used in every test, and problems that are specific for a given experiment.
 You may create as many pools following any category/ rule as you like. Pools are the small puzzle pieces
 that in the end will decide over the content of your exam. Names can range from *A1* to *ExperimentXYZ*.
 You have the freedom of choice. However, please refrain from including empty spaces.
 
-Naming Scheme
+File Naming Scheme
 """"""""""""""""""""""""
 
-Problems and solutions are saved in separate files. Files for problems have the prefix ``problem\_``,
-solutions the prefix ``solution\_``. 
+Problems and solutions are saved in separate ```*.tex```-files. Files for problems must
+have the prefix ``problem_``, solutions the prefix ``solution_``.
 
 You may follow up the prefix with any name to your liking, however mind that problem/ solution pairs
-have to have the exact same description following the prefix. 
+have to have the exact same description following the prefix.
 
 Additionally, please refrain from using "\\" or "/" in your filenames since this will cause compiling errors.
 
 File Content
 """"""""""""""""""""""""
-Subtasks of a problem should be structured in the ``problem`` environment.
 The problem text has to be written between ``\begin{problem}``, ``\end{problem}``.
+Subtasks of a problem should be structured in the ``problem`` environment.
 Every subtask starts with the ``\item`` keyword.
 
 Within the solution files the solution sub-task-text has
@@ -55,8 +55,11 @@ to be written in between ``\begin{solution}``, ``\end{solution}``.
 The solution of every subtask starts with the key
 ``\solitem``.
 
-For both the problem and solution files problem instructions, not part of a subtask should
-be written above their respective surroundings (see example below - text above ``\begin``). 
+For both, the problem and solution files, instructions which are not part of a subtask should
+be written above their respective environments (see example below - text above ``\begin``).
+
+Images can be included using the ```\includegraphics``` command. The path to the image must be
+relative to the problem or soultion file.
 
 It is possible to assign points to problems and
 solutions with the macro ``\Pts{n}``. Where ``n`` is the number of points given at that exact spot.
@@ -64,18 +67,19 @@ During the compiling process the given points will be added automatically for th
 Please be aware that if you would like to show points both on the exam and the solutions,
 you will have to manually input points in the problem and solution file.
 
-Furthermore, this script allows you to create problems with randomly generated paramaters. 
+Furthermore, this script allows you to create problems with randomly generated paramaters.
 In order to implement a random number within given bounds, you can call ``${{context.rnum(__KEY__, lower_bound, upper_bound)}}$``.
 The ``KEY`` gives you the option to reuse the same number within a problem/ solution. It follows a simple structure: ``__KEY{number}__``.
-Therefore, in order to reuse a number you can for example provide ``__KEY1__`` within all calls of the context.rnum function, 
+Therefore, in order to reuse a number you can for example provide ``__KEY1__`` within all calls of the context.rnum function,
 where the same value is required. While those random values do transfer over to the according solution files, they do not affect unlinked problems.
 This paramaterization can also be used to calculate the solutions for your given problems, simply by providing your formula with the according
-random values. More information on how to implement paramaterization into your exams is given in our third tutorial. 
-   
+random values. More information on how to implement paramaterization into your exams is given in our third tutorial.
+
+
 
 Problem example:
 ::
-   
+
    This is an example problem.
    \begin{problem}
    \item Are you happy? \Pts{10}
@@ -100,7 +104,7 @@ Solution example:
 Settings
 --------------------
 
-There are the following options for the exam creation, which can be configured 
+There are the following options for the exam creation, which can be configured
 in a json settings file:
 
 -  *title*: Title of the exam
@@ -112,15 +116,15 @@ in a json settings file:
 
 -  *number_of_groups*: Determines the number of different groups.
 
--  *copies*: When using paramaterization, this is the number of students who are taking the exam. 
-   
+-  *copies*: When using paramaterization, this is the number of students who are taking the exam.
+
 -  *page_format_exam*: Set this according on the planned printing format - Opions are "A4" or "A5"
 
 -  *page_format_solution*: Set this according on the planned printing format - Opions are "A4" or "A5"
 
 - options
    -  *generate_single_pdfs*: Should individual pdf files be created for each
-      exam (true/ false) 
+      exam (true/ false)
    -  *generate_sumo_pdf*: Should a sumo-file be created (true/ false)
 
    -  *delete_temp_data*: Should temporary data be deleted (true; false) true
@@ -130,26 +134,26 @@ in a json settings file:
 
    Enabling *generate_sumo_pdf* allows creating the tests for the entire semester in
    one go. However, this is only useful if the problems and solutions are
-   final and will not have to be corrected afterwards. 
+   final and will not have to be corrected afterwards.
 
 - sumo_options
    -  *solution_copies*: Number of solution copies in the sumo file
-   -  *exam_copies*: Number of copies per exam in the sumo file. 
+   -  *exam_copies*: Number of copies per exam in the sumo file.
 
 .. hint::
 
    The final amount of copies is determined by the product of *copies* and *exam_copies*.
 
-   When using *paramaterization* in any of your exam problems, ``copies`` is determined by the total 
+   When using *paramaterization* in any of your exam problems, ``copies`` is determined by the total
    number of students taking the exam and ``exam_copies`` should therefore be set to 1, unless you would
    like to have more copies of the entire exam.
-   On the other hand when **not** using paramaterization, copies should be set to 1 and exam_copies should 
+   On the other hand when **not** using paramaterization, copies should be set to 1 and exam_copies should
    be set to the total amount of students taking the exam. This allows you to print every individual exam as
    often as you like, without having to always print all questions for a predetermined amount of students.
 
 - *exams*: This is where you will be able to build your exams out of your pools.
-   For example: "TestExam": ["A1", "B", "CV03"] will create an exam called TestExam consisting 
-   of 3 problems randomly newly drawn from the given pools for each group_pair. A more detailed 
+   For example: "TestExam": ["A1", "B", "CV03"] will create an exam called TestExam consisting
+   of 3 problems randomly newly drawn from the given pools for each group_pair. A more detailed
    example of how to create exams is provided in the tutorial.
 
 Directory setup
@@ -157,7 +161,7 @@ Directory setup
 Following everything mentioned previously, your directory has to contain at least the following:
 
 ::
-   
+
    ├───pool_data
    │   └───examplePool_1
    │           problem_example1.tex
@@ -166,7 +170,7 @@ Following everything mentioned previously, your directory has to contain at leas
    ├───settings
    │       settings_example.json
    │
-   └────templates                            
+   └────templates
            template_problem.tex
            template_solution.tex
 
@@ -205,8 +209,8 @@ solutions:
 
 -  *-ms* [PROBLEMPATH] (–make_specific [PROBLEMPATH])
    creates a preview file for the given problem name of the problem
-   
-  
+
+
 
 -  *-h* (–help) for help
 

--- a/examples/example1/templates/template_problem.tex
+++ b/examples/example1/templates/template_problem.tex
@@ -65,6 +65,7 @@
     \setcounter{ProblemPoints}{0}
 }
 
+__GRAPHICS_PATH__
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/examples/example1/templates/template_solution.tex
+++ b/examples/example1/templates/template_solution.tex
@@ -67,6 +67,8 @@
 \item
 }
 
+__GRAPHICS_PATH__
+
 \setlength{\parskip}{2ex}
 \setlength{\parindent}{0ex}
 

--- a/examples/example2/templates/template_problem.tex
+++ b/examples/example2/templates/template_problem.tex
@@ -65,6 +65,7 @@
     \setcounter{ProblemPoints}{0}
 }
 
+__GRAPHICS_PATH__
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/examples/example2/templates/template_solution.tex
+++ b/examples/example2/templates/template_solution.tex
@@ -67,6 +67,8 @@
 \item
 }
 
+__GRAPHICS_PATH__
+
 \setlength{\parskip}{2ex}
 \setlength{\parindent}{0ex}
 

--- a/examples/example3/templates/template_problem.tex
+++ b/examples/example3/templates/template_problem.tex
@@ -65,6 +65,7 @@
     \setcounter{ProblemPoints}{0}
 }
 
+__GRAPHICS_PATH__
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/examples/example3/templates/template_solution.tex
+++ b/examples/example3/templates/template_solution.tex
@@ -67,6 +67,8 @@
 \item
 }
 
+__GRAPHICS_PATH__
+
 \setlength{\parskip}{2ex}
 \setlength{\parindent}{0ex}
 

--- a/src/exam_generator/funcs.py
+++ b/src/exam_generator/funcs.py
@@ -520,10 +520,11 @@ def create_file_content(
     file_content = file_content.replace("__GROUP__", group_name)
 
     # Creation of the problem strings + implementation in the LaTeX file
-    problem_string = create_problem_content(
+    problem_string, graphics_path = create_problem_content(
         tests_per_group, group, test_index, prob_sol_index, student, test
     )
 
+    file_content = file_content.replace("__GRAPHICS_PATH__", graphics_path)
     file_content = file_content.replace("__PROBLEMS__", problem_string)
 
     return file_content
@@ -553,21 +554,27 @@ def create_problem_content(
     :param test: name of test
     :type test: str
 
-    :returns: string concisting of all problems for a student
-    :rtype: str
+    :returns: 2-element tuple: string consisting of all problems for a student
+                               and a string the graphicspath
+    :rtype: (str, str)
     """
     problem_string = ""
+    graphics_dirs = ""
     for prob_sol in tests_per_group[group][test_index]:
         problem_string += f"\\item\n"
         pool_name = prob_sol[2]
+        problem_dir = os.path.join(os.getcwd(), "pool_data", pool_name)
         with open(
-            os.path.join(os.getcwd(), "pool_data", pool_name, prob_sol[prob_sol_index]),
+            os.path.join(problem_dir, prob_sol[prob_sol_index]),
             "r", encoding="utf8"
         ) as d:
             problem_str = d.read()
         problem_string += f"{problem_str}\n\n"
+        problem_dir = problem_dir.replace("\\", "/")
+        graphics_dirs += f"{{{problem_dir}}}"
 
     problem_string = replace_keys(problem_string, test, group, student)
+    graphics_dirs = f"\\graphicspath{{{graphics_dirs}}}"
 
     temp_file = "temp_file.tex"
     with open(temp_file, "w", encoding="utf8") as temp:
@@ -580,7 +587,7 @@ def create_problem_content(
 
     delete_command("temp_file")
 
-    return problem_string
+    return problem_string, graphics_dirs
 
 
 ##############################################

--- a/templates/template_problem.tex
+++ b/templates/template_problem.tex
@@ -65,6 +65,7 @@
     \setcounter{ProblemPoints}{0}
 }
 
+__GRAPHICS_PATH__
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/templates/template_solution.tex
+++ b/templates/template_solution.tex
@@ -67,6 +67,8 @@
 \item
 }
 
+__GRAPHICS_PATH__
+
 \setlength{\parskip}{2ex}
 \setlength{\parindent}{0ex}
 


### PR DESCRIPTION
Added new keyword `__GRAPHICS_PATH__` to templates.

It will be replaced by `\graphicspath{{problem_dir_01}{problem_dir_02}...}` so it is convinient to include images in the exams.

Resolves #9

ToDo:

- [x] Final test with real world example
- [x] Update documentation
- [x] Update examples