### PR TITLE
use seed=None as default (fix 20)

### DIFF
--- a/src/exam_generator/funcs.py
+++ b/src/exam_generator/funcs.py
@@ -52,11 +52,11 @@ def check_directory(root_directory) -> bool:
     return True
 
 
-def initialize_random_number_generator(seed=1024):
+def initialize_random_number_generator(seed=None):
     """
     Initializes random seed.
 
-    :param seed: seed. Defaults to 1024 for debugging purposes.
+    :param seed: int or float; Seed for random number generator. Default: None (use system clock).
     :type seed: int
     """
     random.seed(seed)


### PR DESCRIPTION
As @sputeanus suggests in #20 this is the expected option for randomness: when no `seed` parameter is specified explicitly then the behavior should be random across different runs of the program.


However, this change might make debugging more complicated. Also: I have not checked, whether this change needs to be reflected in the docs.