### PR TITLE
Moved seed value into settings file

### DIFF
--- a/docs/source/userdoc.rst
+++ b/docs/source/userdoc.rst
@@ -114,6 +114,12 @@ in a json settings file:
 
 -  *semester*: Current Semester for example: "WS 2022/23"
 
+-  *seed* (optional): A non negative integer or floating point value for seeding
+   the random number generator. This is useful to ensure that the same exams are
+   compiled from run to run, e.g. after fixing errors in one of the tasks. If
+   this parameter is not set the random number generator is initialized using
+   the system date.
+
 -  *number_of_groups*: Determines the number of different groups.
 
 -  *copies*: When using paramaterization, this is the number of students who are taking the exam.
@@ -188,15 +194,6 @@ directory. With these it is now possible to easily create exams:
    the chosen settings file]) creates a folder in which the created
    tests, based on the provided settings, are saved
 
-If you would like to select a new random seed, allowing for different results
-when creating the same exam:
-
-- *-rs* [seed]
-
-.. Hint::
-
-   This only works in combination with creating an exam (-ct).
-
 
 Additionally, the script can help with the creation/ review of problems/
 solutions:
@@ -231,11 +228,11 @@ At the root directory you can now call:
 
 
 exam_generator [-h] [-ct] SETTINGSPATH [-ma] [-mp] POOLPATH
-[-ms] PROBLEMPATH [-rs] SEED
+[-ms] PROBLEMPATH
 
 
 **Syntax for the stand-alone application**
 
 exam_generator.exe [-h] [-ct] SETTINGSPATH [-ma] [-mp] POOLPATH [-ms]
-PROBLEMPATH [-rs] SEED
+PROBLEMPATH
 

--- a/src/exam_generator/funcs.py
+++ b/src/exam_generator/funcs.py
@@ -169,7 +169,7 @@ def check_settings(settings, settings_file):
 
     if isinstance(settings.seed, (int, float)) and settings.seed < 0:
         raise SettingsError(
-            f"{errorInfo()} Random seed needs to larger or equal to zero in {settings_file}."
+            f"{errorInfo()} Random seed needs to be larger or equal to zero in {settings_file}."
         )
 
 
@@ -415,7 +415,8 @@ def generate_tex_files(
         template_solution = d.read()
 
     for group in range(number_group_pairs):
-        group_name = f"{group + 1}"
+        #group_name = f"{group + 1}"
+        group_name = f"{2*group + 1}-{2*group + 2}"
 
         for test_index, test_typ in enumerate(test_list_variant):
             # Problem
@@ -831,7 +832,8 @@ def combine_group_files(
     for test in test_list_variant:
         name = test.name.replace(" ", "")
         for group in range(groups):
-            group_name = f"{group + 1}"
+            #group_name = f"{group + 1}"
+            group_name = f"{2*group + 1}-{2*group + 2}"
             group_prob_files = [
                 file
                 for file in pdf_files

--- a/src/exam_generator/funcs.py
+++ b/src/exam_generator/funcs.py
@@ -167,6 +167,11 @@ def check_settings(settings, settings_file):
             f"{errorInfo()} Number of copies has to be at least one in {settings_file}."
         )
 
+    if isinstance(settings.seed, (int, float)) and settings.seed < 0:
+        raise SettingsError(
+            f"{errorInfo()} Random seed needs to larger or equal to zero in {settings_file}."
+        )
+
 
 def pull_pool_data(latex_directory):
     """

--- a/src/exam_generator/main.py
+++ b/src/exam_generator/main.py
@@ -53,13 +53,6 @@ def exam_generator(args):
 
     # Settings are adjusted in the settings json files in the settings directory and then loaded into Python
     # No change of settings in this program!
-
-    if args.random_seed is not None:
-        seed = args.random_seed
-        initialize_random_number_generator(seed)
-    else:
-        initialize_random_number_generator()
-
     settings_path = args.create_test
 
     path_settings = os.path.join(root_directory, settings_path)
@@ -83,6 +76,12 @@ def exam_generator(args):
     settings = Dict(settings_dictionary)
 
     check_settings(settings, settings_name)
+
+    # Initialize random number generator
+    if "seed" in settings.keys():
+        initialize_random_number_generator(settings.seed)
+    else:
+        initialize_random_number_generator()
 
     # assigning int values to string decleration of pages_per_sheet for usage in sumo func
     if settings.page_format_exam == "A4":
@@ -277,14 +276,6 @@ def main():
     )
 
     parser.add_argument(
-        "-rs",
-        "--random_seed",
-        metavar="SEED",
-        type=int,
-        help="Set a new random seed, allowing the same exam to be created, yet with different problems pulled. Provide a positive integer of your liking.",
-    )
-
-    parser.add_argument(
         "--bootstrap",
         action="store_true",
         help="bootstrap the example content in the current working directory",
@@ -302,13 +293,6 @@ def main():
         and (args.make_specific is None)
     ):
         parser.error("Please choose at least one of the options. For help type: -h")
-
-    elif args.random_seed is not None and args.create_test is None:
-        parser.error("You can only select a random seed when creating an exam.")
-
-    elif args.random_seed is not None:
-        if args.random_seed <= 0:
-            parser.error("Please select a positive integer as your random seed.")
 
     else:
         exam_generator(args)

--- a/src/exam_generator/main.py
+++ b/src/exam_generator/main.py
@@ -78,7 +78,7 @@ def exam_generator(args):
     check_settings(settings, settings_name)
 
     # Initialize random number generator
-    if "seed" in settings.keys():
+    if "seed" in settings:
         initialize_random_number_generator(settings.seed)
     else:
         initialize_random_number_generator()


### PR DESCRIPTION
It must be possible to generate the same exams from run to run. Setting the seed value from the command line is error-prone. Hence, this option has been moved into the settings file. If no seed value is specified in the settings file the seed is generated from the system date.